### PR TITLE
fix: 修改无法读取body

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,11 @@
 import Koa from 'koa';
 import json from 'koa-json';
-import bodyparser from 'koa-bodyparser';
+import koaBody from 'koa-body';
 import cors from 'koa-cors';
 import accessLogger from './middleware/logs'; // 日志输出
 import signale from './config/signale'; // shell输出美化
 import InitManager from './routes';
-import Parameter  from 'koa-parameter';
+import Parameter from 'koa-parameter';
 import {
   CustomError,
   HttpError
@@ -17,38 +17,34 @@ import catchError from './middleware/exception'
 import constants from './middleware/error/constants'
 
 const app = new Koa()
-Parameter(app);
-
-InitManager.initCore(app); // ! 自动注入接口路由
+Parameter(app)
 
 app
   .use(accessLogger()) // !  日志服务
   .use(catchError)
   .use(cors()) // ! 跨域服务
-  .use(
-    bodyparser({ // ! middlewares
-      enableTypes: ['json', 'form', 'text'],
-    })
-  )
   .use(json())
+  .use(koaBody())
   .use((ctx, next) => {
-      return next().catch((err) => {
-        let code = 500
-        let msg = 'unknown error'
-
-        if (err instanceof CustomError || err instanceof HttpError) {
-          const res = err.getCodeMsg()
-          ctx.status = err instanceof HttpError ? res.code : 200
-          code = res.code
-          msg = res.msg
-        } else {
-          ctx.status = code
-          console.error('err', err)
-        }
-        ctx.body = format({}, code, msg)
-      })
+    return next().catch((err) => {
+      let code = 500
+      let msg = 'unknown error'
+      if (err instanceof CustomError || err instanceof HttpError) {
+        const res = err.getCodeMsg()
+        ctx.status = err instanceof HttpError ? res.code : 200
+        code = res.code
+        msg = res.msg
+      } else {
+        ctx.status = code
+        console.error('err', err)
+      }
+      ctx.body = format({}, code, msg)
+    })
   })
-  .use(async () => {// 404
+// 路由监听事件之后先注册body，再注册router.routes()，最后监听3000端口
+InitManager.initCore(app); // ! 自动注入接口路由
+
+app.use(async () => { // 404
     throw new HttpError(constants.HTTP_CODE.NOT_FOUND)
   })
   .on('error', (err, ctx) => {
@@ -56,7 +52,8 @@ app
     signale.fatal('server error', err, ctx)
   })
   .listen(() => {
-    signale.success('服务启动完成，访问 http://localhost:3000')
+    signale.success('服务启动完成，访问 http://localhost:8888')
   })
+
 
 module.exports = app


### PR DESCRIPTION
### 问题
 post请求时，无法读取到body内容


### 如何解决

路由监听事件之后先注册bodyparser，再注册router.routes()，最后监听3000端口，调整自动注册路由和body的位置

``` js
app
  .use(koaBody())

// 路由监听事件之后先注册body，再注册router.routes()，最后监听3000端口
InitManager.initCore(app); // ! 自动注入接口路由

app.use(async () => { // 404
    throw new HttpError(constants.HTTP_CODE.NOT_FOUND)
  })
  .on('error', (err, ctx) => {
    // ! shell 启动失败
    signale.fatal('server error', err, ctx)
  })
  .listen(() => {
    signale.success('服务启动完成，访问 http://localhost:8888')
  })


```